### PR TITLE
Provide web page on /docs/

### DIFF
--- a/docs/01_try-overview.md
+++ b/docs/01_try-overview.md
@@ -2,6 +2,7 @@
 id: user-guide-introduction
 title: Apache StreamPipes Documentation
 sidebar_label: Overview
+slug: /
 ---
 
 This is the documentation of Apache StreamPipes.

--- a/docs/user-guide-first-steps.md
+++ b/docs/user-guide-first-steps.md
@@ -205,5 +205,5 @@ It is recommended to stop the last pipeline, because it will keep creating notif
 
 We hope we gave you an easy quick start into StreamPipes.
 If you have any questions or suggestions, just send us an email.
-From here on you can explore all features in the [User Guide](user-guide-introduction) or go to the [Developer Guide](extend-setup) to learn how to write your own StreamPipes processing elements.
+From here on you can explore all features in the [User Guide](./) or go to the [Developer Guide](extend-setup) to learn how to write your own StreamPipes processing elements.
 


### PR DESCRIPTION

### Purpose
https://streampipes.apache.org/docs/ is sometimes referenced as the location of the documentation. E.g. on the start page of a StreamPipes instance.
This url currently leads to a webserver index page.
What do you think of the idear to provide the  StreamPipes [documentation page](https://streampipes.apache.org/docs/user-guide-introduction/) instead?

### Approach
Set slug to / means that the url is now  https://streampipes.apache.org/docs/ .


