### PR TITLE
Provide 'User Guide' page on /docs

### DIFF
--- a/docs/01_try-overview.md
+++ b/docs/01_try-overview.md
@@ -2,6 +2,7 @@
 id: user-guide-introduction
 title: Apache StreamPipes Documentation
 sidebar_label: Overview
+slug: /
 ---
 
 This is the documentation of Apache StreamPipes.

--- a/docs/user-guide-first-steps.md
+++ b/docs/user-guide-first-steps.md
@@ -205,5 +205,5 @@ It is recommended to stop the last pipeline, because it will keep creating notif
 
 We hope we gave you an easy quick start into StreamPipes.
 If you have any questions or suggestions, just send us an email.
-From here on you can explore all features in the [User Guide](user-guide-introduction) or go to the [Developer Guide](extend-setup) to learn how to write your own StreamPipes processing elements.
+From here on you can explore all features in the [User Guide](./) or go to the [Developer Guide](extend-setup) to learn how to write your own StreamPipes processing elements.
 

--- a/website-v2/blog/2019-09-05-release-0630.md
+++ b/website-v2/blog/2019-09-05-release-0630.md
@@ -56,7 +56,7 @@ In addition, we completely reworked the Connect UI. The schema view now lets you
 
 
 ## Documentation
-We updated and restructured the user guide, which now consists of four parts: [Introduction](/docs/user-guide-introduction), [Tour](/docs/user-guide-tour), [Installation](/docs/user-guide-installation) and [First Steps](/docs/user-guide-first-steps).
+We updated and restructured the user guide, which now consists of four parts: [Introduction](/docs/), [Tour](/docs/user-guide-tour), [Installation](/docs/user-guide-installation) and [First Steps](/docs/user-guide-first-steps).
 We also updated all screenshots to reflect the current look and feel of StreamPipes.
 
 In addition, the developer guide was further extended (e.g., there is now a new tutorial on creating data sinks). Maven archetypes are now the recommended way to create new pipeline elements.

--- a/website-v2/blog/2022-09-05-using-factory.io-with-streampipes.md
+++ b/website-v2/blog/2022-09-05-using-factory.io-with-streampipes.md
@@ -28,7 +28,7 @@ a PLC training platform. We will need it to simulate the live data.
 
 The next step is to connect the PLC to StreamPipes. To achieve this we need to create an adapter.
 
-- Start <a href="https://streampipes.apache.org/docs/docs/user-guide-introduction.html">*StreamPipes*</a>, go to the *
+- Start <a href="https://streampipes.apache.org/docs/docs/">*StreamPipes*</a>, go to the *
   *CONNECT** menu and create a **NEW ADAPTER**.
 - Select the **PLC4X S7** adapter, insert the **IP-address** of your PLC and **import the file** with the PLC tags (see
   below). Then click **NEXT** on the bottom right.

--- a/website-v2/src/components/Teaser.tsx
+++ b/website-v2/src/components/Teaser.tsx
@@ -25,7 +25,7 @@ const Teaser = (props) => (
             <div className={"teaser-actions text-center"}>
               <a href="/download/" className="sp-button sp-button-large sp-button-blue sp-button-margin"><i
                 className="fas fa-download"></i> Download</a>
-              <a href="/docs/user-guide-introduction/"
+              <a href="/docs"
                  className="sp-button sp-button-large sp-button-gray sp-button-margin"><i
                 className="fas fa-book"></i> Documentation
               </a>

--- a/website-v2/src/components/home/Support.tsx
+++ b/website-v2/src/components/home/Support.tsx
@@ -9,7 +9,7 @@ const Support = (props) => (
       <section className="d-sm-flex clearfix align-items-center justify-content-center">
         <SupportLink imageSrc={"/img/open_source/icon-github.png"} href={"https://www.github.com/apache/streampipes"}
                      label={"Github"}></SupportLink>
-        <SupportLink imageSrc={"/img/open_source/icon-docs.png"} href={"/docs/user-guide-introduction/"}
+        <SupportLink imageSrc={"/img/open_source/icon-docs.png"} href={"/docs/"}
                      label={"Documentation"}></SupportLink>
         <SupportLink imageSrc={"/img/open_source/icon-docker.png"} href={"https://hub.docker.com/u/apachestreampipes"}
                      label={"Docker Hub"}></SupportLink>

--- a/website-v2/src/navbar/navbar.js
+++ b/website-v2/src/navbar/navbar.js
@@ -9,7 +9,7 @@ module.exports = [
     "position": "right",
     items: [
       {
-        "to": "docs/user-guide-introduction",
+        "to": "docs/",
         "label": "Apache StreamPipes - User Guide",
       },
       {

--- a/website-v2/src/pages/download.tsx
+++ b/website-v2/src/pages/download.tsx
@@ -49,7 +49,7 @@ const Downloads: FC = () => (
                                                     </span>
               </div>
               <div className="col-md-11 col-9">
-                Check the <a href="/docs/user-guide-introduction/"> user
+                Check the <a href="/docs/"> user
                 guide</a> and learn how to make your first steps with StreamPipes!
               </div>
             </div>


### PR DESCRIPTION
   ### Purpose
   https://streampipes.apache.org/docs/ is sometimes referenced as the location of the documentation. E.g. on the start page of a StreamPipes instance.
   This url currently leads to a webserver index page.
   What do you think of the idear to provide the  StreamPipes [documentation page](https://streampipes.apache.org/docs/user-guide-introduction/) instead?
   
   ### Approach
   Set slug to / means that the url is now  https://streampipes.apache.org/docs/ .
   

